### PR TITLE
Build node_modules before archiving the function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,11 +71,21 @@ resource "aws_cloudwatch_event_target" "default" {
 }
 
 # Lambda function
+## Build node_modules
+data "external" "node_modules" {
+  program = ["bash", "-c", <<EOT
+  npm ci >&2 && echo "{\"sso_build_destination\": \"function\"}"
+EOT
+  ]
+  working_dir = "${path.module}/function"
+}
+
 ## ZIP up the function
 data "archive_file" "function" {
   type        = "zip"
   output_path = "${path.module}/function.zip"
   source_dir  = "${path.module}/function"
+  depends_on  = [data.external.node_modules]
 }
 
 ## Create the Lambda function


### PR DESCRIPTION
Currently, if you use this module from a fresh state, it won't include the `node_modules` directory which is required for this Lambda function.

This resolves this by using an external data source to invoke `npm ci` (clean install) before packaging up the zip.