### PR TITLE
Pin provider versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,17 @@
 terraform {
   required_providers {
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
+      version = ">=2.2.0"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">=3.6.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">=2.1.0"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
This PR:

- pins provider versions
- adds a missing required provider (`external`)
- adds an empty outputs.tf file to meet best practice for Terraform
- updates the required Terraform version to be 0.15