### PR TITLE
Update Lambda function to Node 14.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_lambda_function" "default" {
   handler          = "index.handler"
   kms_key_arn      = data.aws_kms_alias.lambda.target_key_arn
   role             = aws_iam_role.default.arn
-  runtime          = "nodejs12.x"
+  runtime          = "nodejs14.x"
   source_code_hash = data.archive_file.function.output_base64sha256
   timeout          = 300
   environment {


### PR DESCRIPTION
This PR updates the Lambda function to use Node 14.x, as [Node 12.x has been deprecated](https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-12-x-in-the-aws-sdk-for-javascript-v3/).