### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/operations-engineering


### PR DESCRIPTION
This PR adds @ministryofjustice/operations-engineering as the CODEOWNERS for this repository.