### PR TITLE
Refactor to use Identity Store API to allow for deprovisioning users and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # moj-terraform-scim-github
 
-This Terraform module to configure a Lambda for SCIM provisioning from GitHub, syncing GitHub to AWS SSO.
+This Terraform module configures a Lambda function for provisioning (and deprovisioning) AWS SSO Identity Store users and groups from GitHub.
+
+The Lambda function used to use the SCIM endpoints (hence its name, _moj-terraform-scim-github_), but now uses the direct [Identity Store API](https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_Operations.html). The SCIM API has limitations such as not being able to list more than 50 groups or members (and doesn't support startIndex, so you can't paginate them), whereas the Identity Store API does allow pagination. This allows us to deprovision users and groups using the Identity Store API, which you cannot do easily with the SCIM API.
 
 ## Usage
 ```
 module "scim" {
-  source              = "github.com/ministryofjustice/moj-terraform-scim-github"
-  github_organisation = "ministryofjustice"
-  github_token        = "${github_token}"
-  sso_aws_region      = "eu-west-2"
-  sso_email_suffix    = "@example.com"
-  sso_scim_token      = "${scim_token}"
-  sso_tenant_id       = "${sso_tenant_id}"
+  source                = "github.com/ministryofjustice/moj-terraform-scim-github"
+  github_organisation   = "ministryofjustice"
+  github_token          = "${github_token}"
+  sso_aws_region        = "eu-west-2"
+  sso_email_suffix      = "@example.com"
+  sso_identity_store_id = "${sso_tenant_id}"
+  not_dry_run           = true
 }
 ```
 
 ## Inputs
-| Name                | Description                                                                 | Type   | Default | Required |
-|---------------------|-----------------------------------------------------------------------------|--------|---------|----------|
-| github_organisation | GitHub organisation to sync SSO groups and members from                     | string | n/a     | yes      |
-| github_token        | GitHub token to perform API calls. Must have the following scopes: read:org | string | n/a     | yes      |
-| sso_aws_region      | Region that AWS SSO is configured in                                        | string | n/a     | yes      |
-| sso_email_suffix    | Email suffix to use in AWS SSO                                              | string | n/a     | yes      |
-| sso_scim_token      | AWS SSO SCIM token                                                          | string | n/a     | yes      |
-| sso_tenant_id       | AWS SSO tenant ID                                                           | string | n/a     | yes      |
-| tags                | Tags to apply to resources, where applicable                                | map    | {}      | no       |
+| Name                  | Description                                                                    | Type   | Default | Required |
+|-----------------------|--------------------------------------------------------------------------------|--------|---------|----------|
+| github_organisation   | GitHub organisation to sync SSO groups and members from                        | string | n/a     | yes      |
+| github_token          | GitHub token to perform API calls. Must have the following scopes: read:org    | string | n/a     | yes      |
+| sso_aws_region        | Region that AWS SSO is configured in                                           | string | n/a     | yes      |
+| sso_email_suffix      | Email suffix to use in AWS SSO                                                 | string | n/a     | yes      |
+| sso_identity_store_id | AWS SSO Identity Store ID. Available from the AWS SSO Identity Source settings | string | n/a     | yes      |
+| not_dry_run           | Whether this Lambda function is or is _not_ a dry-run                          | string | false   | no       |
+| tags                  | Tags to apply to resources, where applicable                                   | map    | {}      | no       |

--- a/function/package-lock.json
+++ b/function/package-lock.json
@@ -9,20 +9,862 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@octokit/rest": "^19.0.4",
-        "axios": "^0.27.2",
-        "axios-retry": "^3.3.1"
+        "@aws-sdk/client-identitystore": "^3.186.0",
+        "@octokit/rest": "^19.0.4"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-identitystore": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-identitystore/-/client-identitystore-3.186.0.tgz",
+      "integrity": "sha512-l41pzYCd3ttA2idCWviEkDyexmk35NWKFFF4Fn71zFQXGk43lehO5B6rEaNLWKUmM8/IAxETbxodHvBdFJeKNQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -185,88 +1027,39 @@
         "@octokit/openapi-types": "^12.7.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
-      "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+    "node_modules/fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "bin": {
+        "xml2js": "cli.js"
       },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/is-plain-object": {
@@ -275,36 +1068,6 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/node-fetch": {
@@ -334,20 +1097,28 @@
         "wrappy": "1"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -370,12 +1141,719 @@
     }
   },
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.186.0.tgz",
+      "integrity": "sha512-JFvvvtEcbYOvVRRXasi64Dd1VcOz5kJmPvtzsJ+HzMHvPbGGs/aopOJAZQJMJttzJmJwVTay0QL6yag9Kk8nYA==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-identitystore": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-identitystore/-/client-identitystore-3.186.0.tgz",
+      "integrity": "sha512-l41pzYCd3ttA2idCWviEkDyexmk35NWKFFF4Fn71zFQXGk43lehO5B6rEaNLWKUmM8/IAxETbxodHvBdFJeKNQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.186.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.186.0.tgz",
+      "integrity": "sha512-qwLPomqq+fjvp42izzEpBEtGL2+dIlWH5pUCteV55hTEwHgo+m9LJPIrMWkPeoMBzqbNiu5n6+zihnwYlCIlEA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.0.tgz",
+      "integrity": "sha512-lyAPI6YmIWWYZHQ9fBZ7QgXjGMTtktL5fk8kOcZ98ja+8Vu0STH1/u837uxqvZta8/k0wijunIL3jWUhjsNRcg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-node": "3.186.0",
+        "@aws-sdk/fetch-http-handler": "3.186.0",
+        "@aws-sdk/hash-node": "3.186.0",
+        "@aws-sdk/invalid-dependency": "3.186.0",
+        "@aws-sdk/middleware-content-length": "3.186.0",
+        "@aws-sdk/middleware-host-header": "3.186.0",
+        "@aws-sdk/middleware-logger": "3.186.0",
+        "@aws-sdk/middleware-recursion-detection": "3.186.0",
+        "@aws-sdk/middleware-retry": "3.186.0",
+        "@aws-sdk/middleware-sdk-sts": "3.186.0",
+        "@aws-sdk/middleware-serde": "3.186.0",
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/middleware-user-agent": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/node-http-handler": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/smithy-client": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "@aws-sdk/util-base64-node": "3.186.0",
+        "@aws-sdk/util-body-length-browser": "3.186.0",
+        "@aws-sdk/util-body-length-node": "3.186.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.186.0",
+        "@aws-sdk/util-defaults-mode-node": "3.186.0",
+        "@aws-sdk/util-user-agent-browser": "3.186.0",
+        "@aws-sdk/util-user-agent-node": "3.186.0",
+        "@aws-sdk/util-utf8-browser": "3.186.0",
+        "@aws-sdk/util-utf8-node": "3.186.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.186.0.tgz",
+      "integrity": "sha512-l8DR7Q4grEn1fgo2/KvtIfIHJS33HGKPQnht8OPxkl0dMzOJ0jxjOw/tMbrIcPnr2T3Fi7LLcj3dY1Fo1poruQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-config-provider": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.186.0.tgz",
+      "integrity": "sha512-N9LPAqi1lsQWgxzmU4NPvLPnCN5+IQ3Ai1IFf3wM6FFPNoSUd1kIA2c6xaf0BE7j5Kelm0raZOb4LnV3TBAv+g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.186.0.tgz",
+      "integrity": "sha512-iJeC7KrEgPPAuXjCZ3ExYZrRQvzpSdTZopYgUm5TnNZ8S1NU/4nvv5xVy61JvMj3JQAeG8UDYYgC421Foc8wQw==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/url-parser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.186.0.tgz",
+      "integrity": "sha512-ecrFh3MoZhAj5P2k/HXo/hMJQ3sfmvlommzXuZ/D1Bj2yMcyWuBhF1A83Fwd2gtYrWRrllsK3IOMM5Jr8UIVZA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.186.0.tgz",
+      "integrity": "sha512-HIt2XhSRhEvVgRxTveLCzIkd/SzEBQfkQ6xMJhkBtfJw1o3+jeCk+VysXM0idqmXytctL0O3g9cvvTHOsUgxOA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/credential-provider-ini": "3.186.0",
+        "@aws-sdk/credential-provider-process": "3.186.0",
+        "@aws-sdk/credential-provider-sso": "3.186.0",
+        "@aws-sdk/credential-provider-web-identity": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.186.0.tgz",
+      "integrity": "sha512-ATRU6gbXvWC1TLnjOEZugC/PBXHBoZgBADid4fDcEQY1vF5e5Ux1kmqkJxyHtV5Wl8sE2uJfwWn+FlpUHRX67g==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.186.0.tgz",
+      "integrity": "sha512-mJ+IZljgXPx99HCmuLgBVDPLepHrwqnEEC/0wigrLCx6uz3SrAWmGZsNbxSEtb2CFSAaczlTHcU/kIl7XZIyeQ==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.186.0.tgz",
+      "integrity": "sha512-KqzI5eBV72FE+8SuOQAu+r53RXGVHg4AuDJmdXyo7Gc4wS/B9FNElA8jVUjjYgVnf0FSiri+l41VzQ44dCopSA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.186.0.tgz",
+      "integrity": "sha512-k2v4AAHRD76WnLg7arH94EvIclClo/YfuqO7NoQ6/KwOxjRhs4G6TgIsAZ9E0xmqoJoV81Xqy8H8ldfy9F8LEw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-base64-browser": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.186.0.tgz",
+      "integrity": "sha512-G3zuK8/3KExDTxqrGqko+opOMLRF0BwcwekV/wm3GKIM/NnLhHblBs2zd/yi7VsEoWmuzibfp6uzxgFpEoJ87w==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.186.0.tgz",
+      "integrity": "sha512-hjeZKqORhG2DPWYZ776lQ9YO3gjw166vZHZCZU/43kEYaCZHsF4mexHwHzreAY6RfS25cH60Um7dUh1aeVIpkw==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.186.0.tgz",
+      "integrity": "sha512-fObm+P6mjWYzxoFY4y2STHBmSdgKbIAXez0xope563mox62I8I4hhVPUCaDVydXvDpJv8tbedJMk0meJl22+xA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.186.0.tgz",
+      "integrity": "sha512-Ol3c1ks3IK1s+Okc/rHIX7w2WpXofuQdoAEme37gHeml+8FtUlWH/881h62xfMdf+0YZpRuYv/eM7lBmJBPNJw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.186.0.tgz",
+      "integrity": "sha512-5bTzrRzP2IGwyF3QCyMGtSXpOOud537x32htZf344IvVjrqZF/P8CDfGTkHkeBCIH+wnJxjK+l/QBb3ypAMIqQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.186.0.tgz",
+      "integrity": "sha512-/1gGBImQT8xYh80pB7QtyzA799TqXtLZYQUohWAsFReYB7fdh5o+mu2rX0FNzZnrLIh2zBUNs4yaWGsnab4uXg==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.186.0.tgz",
+      "integrity": "sha512-Za7k26Kovb4LuV5tmC6wcVILDCt0kwztwSlB991xk4vwNTja8kKxSt53WsYG8Q2wSaW6UOIbSoguZVyxbIY07Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.186.0.tgz",
+      "integrity": "sha512-/VI9emEKhhDzlNv9lQMmkyxx3GjJ8yPfXH3HuAeOgM1wx1BjCTLRYEWnTbQwq7BDzVENdneleCsGAp7yaj80Aw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/service-error-classification": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.186.0.tgz",
+      "integrity": "sha512-GDcK0O8rjtnd+XRGnxzheq1V2jk4Sj4HtjrxW/ROyhzLOAOyyxutBt+/zOpDD6Gba3qxc69wE+Cf/qngOkEkDw==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.186.0.tgz",
+      "integrity": "sha512-6FEAz70RNf18fKL5O7CepPSwTKJEIoyG9zU6p17GzKMgPeFsxS5xO94Hcq5tV2/CqeHliebjqhKY7yi+Pgok7g==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.186.0.tgz",
+      "integrity": "sha512-riCJYG/LlF/rkgVbHkr4xJscc0/sECzDivzTaUmfb9kJhAwGxCyNqnTvg0q6UO00kxSdEB9zNZI2/iJYVBijBQ==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/signature-v4": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.186.0.tgz",
+      "integrity": "sha512-fENMoo0pW7UBrbuycPf+3WZ+fcUgP9PnQ0jcOK3WWZlZ9d2ewh4HNxLh4EE3NkNYj4VIUFXtTUuVNHlG8trXjQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.186.0.tgz",
+      "integrity": "sha512-fb+F2PF9DLKOVMgmhkr+ltN8ZhNJavTla9aqmbd01846OLEaN1n5xEnV7p8q5+EznVBWDF38Oz9Ae5BMt3Hs7w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.186.0.tgz",
+      "integrity": "sha512-De93mgmtuUUeoiKXU8pVHXWKPBfJQlS/lh1k2H9T2Pd9Tzi0l7p5ttddx4BsEx4gk+Pc5flNz+DeptiSjZpa4A==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/shared-ini-file-loader": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.186.0.tgz",
+      "integrity": "sha512-CbkbDuPZT9UNJ4dAZJWB3BV+Z65wFy7OduqGkzNNrKq6ZYMUfehthhUOTk8vU6RMe/0FkN+J0fFXlBx/bs/cHw==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.186.0",
+        "@aws-sdk/protocol-http": "3.186.0",
+        "@aws-sdk/querystring-builder": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.186.0.tgz",
+      "integrity": "sha512-nWKqt36UW3xV23RlHUmat+yevw9up+T+953nfjcmCBKtgWlCWu/aUzewTRhKj3VRscbN+Wer95SBw9Lr/MMOlQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.186.0.tgz",
+      "integrity": "sha512-l/KYr/UBDUU5ginqTgHtFfHR3X6ljf/1J1ThIiUg3C3kVC/Zwztm7BEOw8hHRWnWQGU/jYasGYcrcPLdQqFZyQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.186.0.tgz",
+      "integrity": "sha512-mweCpuLufImxfq/rRBTEpjGuB4xhQvbokA+otjnUxlPdIobytLqEs7pCGQfLzQ7+1ZMo8LBXt70RH4A2nSX/JQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.186.0.tgz",
+      "integrity": "sha512-0iYfEloghzPVXJjmnzHamNx1F1jIiTW9Svy5ZF9LVqyr/uHZcQuiWYsuhWloBMLs8mfWarkZM02WfxZ8buAuhg==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.186.0.tgz",
+      "integrity": "sha512-DRl3ORk4tF+jmH5uvftlfaq0IeKKpt0UPAOAFQ/JFWe+TjOcQd/K+VC0iiIG97YFp3aeFmH1JbEgsNxd+8fdxw=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.186.0.tgz",
+      "integrity": "sha512-2FZqxmICtwN9CYid4dwfJSz/gGFHyStFQ3HCOQ8DsJUf2yREMSBsVmKqsyWgOrYcQ98gPcD5GIa7QO5yl3XF6A==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.186.0.tgz",
+      "integrity": "sha512-18i96P5c4suMqwSNhnEOqhq4doqqyjH4fn0YV3F8TkekHPIWP4mtIJ0PWAN4eievqdtcKgD/GqVO6FaJG9texw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "@aws-sdk/util-hex-encoding": "3.186.0",
+        "@aws-sdk/util-middleware": "3.186.0",
+        "@aws-sdk/util-uri-escape": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.186.0.tgz",
+      "integrity": "sha512-rdAxSFGSnrSprVJ6i1BXi65r4X14cuya6fYe8dSdgmFSa+U2ZevT97lb3tSINCUxBGeMXhENIzbVGkRZuMh+DQ==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.186.0.tgz",
+      "integrity": "sha512-NatmSU37U+XauMFJCdFI6nougC20JUFZar+ump5wVv0i54H+2Refg1YbFDxSs0FY28TSB9jfhWIpfFBmXgL5MQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.186.0.tgz",
+      "integrity": "sha512-jfdJkKqJZp8qjjwEjIGDqbqTuajBsddw02f86WiL8bPqD8W13/hdqbG4Fpwc+Bm6GwR6/4MY6xWXFnk8jDUKeA==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.186.0.tgz",
+      "integrity": "sha512-TpQL8opoFfzTwUDxKeon/vuc83kGXpYqjl6hR8WzmHoQgmFfdFlV+0KXZOohra1001OP3FhqvMqaYbO8p9vXVQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.186.0.tgz",
+      "integrity": "sha512-wH5Y/EQNBfGS4VkkmiMyZXU+Ak6VCoFM1GKWopV+sj03zR2D4FHexi4SxWwEBMpZCd6foMtihhbNBuPA5fnh6w==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.186.0.tgz",
+      "integrity": "sha512-zKtjkI/dkj9oGkjo+7fIz+I9KuHrVt1ROAeL4OmDESS8UZi3/O8uMDFMuCp8jft6H+WFuYH6qRVWAVwXMiasXw==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.186.0.tgz",
+      "integrity": "sha512-U7Ii8u8Wvu9EnBWKKeuwkdrWto3c0j7LG677Spe6vtwWkvY70n9WGfiKHTgBpVeLNv8jvfcx5+H0UOPQK1o9SQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.186.0.tgz",
+      "integrity": "sha512-be2GCk2lsLWg/2V5Y+S4/9pOMXhOQo4DR4dIqBdR2R+jrMMHN9Xsr5QrkT6chcqLaJ/SBlwiAEEi3StMRmCOXA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.186.0.tgz",
+      "integrity": "sha512-71Qwu/PN02XsRLApyxG0EUy/NxWh/CXxtl2C7qY14t+KTiRapwbDkdJ1cMsqYqghYP4BwJoj1M+EFMQSSlkZQQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.186.0.tgz",
+      "integrity": "sha512-U8GOfIdQ0dZ7RRVpPynGteAHx4URtEh+JfWHHVfS6xLPthPHWTbyRhkQX++K/F8Jk+T5U8Anrrqlea4TlcO2DA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.186.0.tgz",
+      "integrity": "sha512-N6O5bpwCiE4z8y7SPHd7KYlszmNOYREa+mMgtOIXRU3VXSEHVKVWTZsHKvNTTHpW0qMqtgIvjvXCo3vsch5l3A==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.186.0",
+        "@aws-sdk/credential-provider-imds": "3.186.0",
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/property-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.186.0.tgz",
+      "integrity": "sha512-UL9rdgIZz1E/jpAfaKH8QgUxNK9VP5JPgoR0bSiaefMjnsoBh0x/VVMsfUyziOoJCMLebhJzFowtwrSKEGsxNg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.186.0.tgz",
+      "integrity": "sha512-fmQLkH16ga6c5fWsA+kBYklQJjlPlcc8uayTR4avi5g3Nxqm6wPpyUwo5CppwjwWMeS+NXG0HgITtkkGntcRNg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.186.0.tgz",
+      "integrity": "sha512-fddwDgXtnHyL9mEZ4s1tBBsKnVQHqTUmFbZKUUKPrg9CxOh0Y/zZxEa5Olg/8dS/LzM1tvg0ATkcyd4/kEHIhg==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.186.0.tgz",
+      "integrity": "sha512-imtOrJFpIZAipAg8VmRqYwv1G/x4xzyoxOJ48ZSn1/ZGnKEEnB6n6E9gwYRebi4mlRuMSVeZwCPLq0ey5hReeQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.186.0.tgz",
+      "integrity": "sha512-fbRcTTutMk4YXY3A2LePI4jWSIeHOT8DaYavpc/9Xshz/WH9RTGMmokeVOcClRNBeDSi5cELPJJ7gx6SFD3ZlQ==",
+      "requires": {
+        "@aws-sdk/types": "3.186.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.186.0.tgz",
+      "integrity": "sha512-oWZR7hN6NtOgnT6fUvHaafgbipQc2xJCRB93XHiF9aZGptGNLJzznIOP7uURdn0bTnF73ejbUXWLQIm8/6ue6w==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.186.0",
+        "@aws-sdk/types": "3.186.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.186.0.tgz",
+      "integrity": "sha512-n+IdFYF/4qT2WxhMOCeig8LndDggaYHw3BJJtfIBZRiS16lgwcGYvOUmhCkn0aSlG1f/eyg9YZHQG0iz9eLdHQ==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.186.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.186.0.tgz",
+      "integrity": "sha512-7qlE0dOVdjuRbZTb7HFywnHHCrsN7AeQiTnsWT63mjXGDbPeUWQQw3TrdI20um3cxZXnKoeudGq8K6zbXyQ4iA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.186.0",
+        "tslib": "^2.3.1"
       }
     },
     "@octokit/auth-token": {
@@ -505,89 +1983,35 @@
         "@octokit/openapi-types": "^12.7.0"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "axios-retry": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.3.1.tgz",
-      "integrity": "sha512-RohAUQTDxBSWLFEnoIG/6bvmy8l3TfpkclgStjl5MDCMBDgapAWCmr1r/9harQfWC8bzLC8job6UcL1A1Yc+/Q==",
-      "requires": {
-        "@babel/runtime": "^7.15.4",
-        "is-retry-allowed": "^2.2.0"
-      }
-    },
     "before-after-hook": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
-    "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-    },
-    "is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
-      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -605,20 +2029,25 @@
         "wrappy": "1"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
       "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/function/package.json
+++ b/function/package.json
@@ -10,8 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^19.0.4",
-    "axios": "^0.27.2",
-    "axios-retry": "^3.3.1"
+    "@aws-sdk/client-identitystore": "^3.186.0",
+    "@octokit/rest": "^19.0.4"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -100,12 +100,12 @@ resource "aws_lambda_function" "default" {
   timeout          = 300
   environment {
     variables = {
-      GITHUB_ORGANISATION = var.github_organisation
-      GITHUB_TOKEN        = var.github_token
-      SSO_AWS_REGION      = var.sso_aws_region
-      SSO_EMAIL_SUFFIX    = var.sso_email_suffix
-      SSO_SCIM_TOKEN      = var.sso_scim_token
-      SSO_TENANT_ID       = var.sso_tenant_id
+      GITHUB_ORGANISATION   = var.github_organisation
+      GITHUB_TOKEN          = var.github_token
+      SSO_AWS_REGION        = var.sso_aws_region
+      SSO_EMAIL_SUFFIX      = var.sso_email_suffix
+      SSO_IDENTITY_STORE_ID = var.sso_identity_store_id
+      NOT_DRY_RUN           = var.not_dry_run
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,14 +18,15 @@ variable "sso_email_suffix" {
   description = "Email suffix to use in AWS SSO. It's arbitrary, but may be useful if syncing more than one GitHub organisation"
 }
 
-variable "sso_scim_token" {
+variable "sso_identity_store_id" {
   type        = string
-  description = "AWS SSO SCIM token. Generated and shown only once when you turn on AWS SSO automatic SCIM provisioning"
+  description = "AWS SSO Identity Store ID. Available from the AWS SSO Identity Source settings"
 }
 
-variable "sso_tenant_id" {
+variable "not_dry_run" {
   type        = string
-  description = "AWS SSO tenant ID. Available from the Automatic provisioning section in AWS SSO"
+  description = "Whether this is a dry run Lambda or not"
+  default     = false
 }
 
 variable "tags" {


### PR DESCRIPTION
This PR refactors the Lambda function to use the Identity Store API directly, rather than the SCIM endpoints, which hold several limitations, such as the inability to return anything more than the first 50 users and first 50 groups.

By moving to the Identity Store API, we can reconcile users and groups between GitHub users and teams; allowing for the deprovisioning of users and groups from the Identity Store.

Note that the [authentication method checks if a user is part of the `ministryofjustice` organisation](https://github.com/ministryofjustice/moj-terraform-aws-sso/blob/main/auth0-rules/allow-github-organisations.js), so any users who weren't deprovisioned previously can't log in to AWS via AWS SSO anyway, so this is largely to keep the directory in sync with GitHub.