### PR TITLE
Excluding EntraID users and groups from deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 function.zip
 .terraform
+**/**.vscode

--- a/function/utilities.js
+++ b/function/utilities.js
@@ -300,9 +300,9 @@ async function sync (type, payload) {
 
   if (payload.delete.length) {
     for (const needsDeleting of payload.delete) {
-      // Don't delete emails that end with '@justice.gov.uk' [EntraID emails]
-      if (type === 'users' && needsDeleting.email && needsDeleting.email.endsWith('@justice.gov.uk')) {
-        console.log(`Skipping deletion of user with email: ${needsDeleting.email}`)
+      // Don't delete users that end with '@justice.gov.uk' [EntraID emails]
+      if (type === 'users' && needsDeleting.name && needsDeleting.name.endsWith('@justice.gov.uk')) {
+        console.log(`Skipping deletion of user with email: ${needsDeleting.name}`)
         continue;
       }
 

--- a/function/utilities.js
+++ b/function/utilities.js
@@ -300,6 +300,17 @@ async function sync (type, payload) {
 
   if (payload.delete.length) {
     for (const needsDeleting of payload.delete) {
+      // Don't delete emails that end with '@justice.gov.uk' [EntraID emails]
+      if (type === 'users' && needsDeleting.email && needsDeleting.email.endsWith('@justice.gov.uk')) {
+        console.log(`Skipping deletion of user with email: ${needsDeleting.email}`)
+        continue;
+      }
+
+      // Don't delete groups that start with 'entraid-aws-identitycenter-' [EntraID groups]
+      if (type === 'groups' && needsDeleting.name && needsDeleting.name.startsWith('entraid-aws-identitycenter-')) {
+        console.log(`Skipping deletion of group with name: ${needsDeleting.name}`)
+        continue;
+      }
       const parameters = generateParametersForTypeAction(type, 'delete', needsDeleting)
 
       console.log(generateMessage('delete', type, needsDeleting, JSON.stringify(parameters)))


### PR DESCRIPTION
Story Link: https://github.com/ministryofjustice/analytical-platform/issues/4838
Currently the scim function fully reconciles Github membership to AWS Identity Center. However, if we want to progress to a transitional stage where authentication is possible both from Github and EntraID, the Github SCIM function needs to ignore groups and users synchronised from EntraID.

This PR adds logic to skip deletion of users with @justice.gov.uk addresses and groups prefixed with `entraid-aws-identitycenter-` which will be managed by an alternative Lambda function  being developed here: https://github.com/ministryofjustice/moj-terraform-scim-entra-id


Test run with 
`GITHUB_ORGANISATION=ministryofjustice GITHUB_TOKEN=XXXXXXXXX SSO_AWS_REGION=eu-west-2 SSO_EMAIL_SUFFIX='@digital.justice.gov.uk' SSO_IDENTITY_STORE_ID=XXXXX node index.js`
Output snippet:
```
Skipping deletion of user with email: xxxx@justice.gov.uk
Skipping deletion of user with email: xxx@justice.gov.uk
Skipping deletion of user with email: xxx@justice.gov.uk
DRYRUN: [delete] [users] [REDACTED]
Skipping deletion of user with email: xxx@justice.gov.uk
```
