### PR TITLE
Updating the prefix of excluded groups

### DIFF
--- a/function/utilities.js
+++ b/function/utilities.js
@@ -306,8 +306,8 @@ async function sync (type, payload) {
         continue;
       }
 
-      // Don't delete groups that start with 'entraid-aws-identitycenter-' [EntraID groups]
-      if (type === 'groups' && needsDeleting.name && needsDeleting.name.startsWith('entraid-aws-identitycenter-')) {
+      // Don't delete groups that start with 'azure-aws-sso-' [EntraID groups]
+      if (type === 'groups' && needsDeleting.name && needsDeleting.name.startsWith('azure-aws-sso-')) {
         console.log(`Skipping deletion of group with name: ${needsDeleting.name}`)
         continue;
       }


### PR DESCRIPTION
Story Link: https://github.com/ministryofjustice/analytical-platform/issues/4838
Follow-up to this PR: https://github.com/ministryofjustice/moj-terraform-scim-github/pull/116
Currently the scim function fully reconciles Github membership to AWS Identity Center. However, if we want to progress to a transitional stage where authentication is possible both from Github and EntraID, the Github SCIM function needs to ignore groups and users synchronised from EntraID.

The prefix of the excluded groups has now been updated from `entraid-aws-identitycenter-` to `azure-aws-sso-` and this function has been updated accordingly.